### PR TITLE
fix: NullPointerException when loading FASM files without net comments

### DIFF
--- a/src/main/java/fabulator/parse/FasmParser.java
+++ b/src/main/java/fabulator/parse/FasmParser.java
@@ -22,7 +22,9 @@ public class FasmParser {
 
     public FasmParser(String fileName) {
         this.fileName = fileName;
+        this.currentNetName = "default_net";
         this.config = new BitstreamConfiguration();
+        this.config.addNet(this.currentNetName);
 
         try {
             this.parse();


### PR DESCRIPTION
Initialize currentNetName to "default_net" to prevent crashes when parsing FASM files that don't include "# routing for net 'name'" comments before routing entries.