### PR TITLE
fix: ArrayIndexOutOfBoundsException in LOD wire routing

### DIFF
--- a/src/main/java/fabulator/geometry/TileGeometry.java
+++ b/src/main/java/fabulator/geometry/TileGeometry.java
@@ -1,5 +1,7 @@
 package fabulator.geometry;
 
+import fabulator.logging.LogManager;
+import fabulator.logging.Logger;
 import fabulator.object.Location;
 import lombok.Getter;
 import lombok.Setter;
@@ -102,6 +104,18 @@ public class TileGeometry {
 
                 int indexX = (int) wirePoint.getX();
                 int indexY = (int) wirePoint.getY();
+
+                if (indexX < 0 || indexY < 0 || endPoint.getX() > this.width || endPoint.getY() > this.height) {
+                    Logger logger = LogManager.getLogger();
+                    logger.error(
+                            "Wire '" + wireGeom.getName() + "' in tile '" + this.name + "' "
+                            + "exceeds tile bounds (width=" + this.width + ", height=" + this.height + "): "
+                            + "segment from (" + start.getX() + ", " + start.getY() + ") "
+                            + "to (" + end.getX() + ", " + end.getY() + "). "
+                            + "This indicates a geometry input issue."
+                    );
+                    continue;
+                }
 
                 if (start.getX() == end.getX()) {
                     while (indexY <= endPoint.getY()) {


### PR DESCRIPTION
Add bounds in TileGeometry.generateLowLodRouting() to prevent array index out-of-bounds when wire paths exceed tile dimensions. Log an error with wire and tile details when this occurs.

This error should be actually prevented by FABulous itself, however a faulty geometry file should also not crash FABulator without leaving an error message.